### PR TITLE
Support for calling RequestBannerAd with a null 'extras' parameter

### DIFF
--- a/unity/iOS/Plugins/iOS/AdMobPlugin.mm
+++ b/unity/iOS/Plugins/iOS/AdMobPlugin.mm
@@ -138,17 +138,6 @@ extern UIViewController *UnityGetGLViewController();
   self.bannerView.adUnitID = pubId;
   self.bannerView.delegate = self;
   self.bannerView.rootViewController = UnityGetGLViewController();
-  if (positionAdAtTop_ == false) {
-    CGFloat bannerHeightDP = 50.0f;
-    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
-      bannerHeightDP = 90.0f;
-    }
-    CGRect screenRect = [UIScreen mainScreen].bounds;
-    self.bannerView.frame = CGRectMake(screenRect.origin.x,
-                                       screenRect.size.height - bannerHeightDP,
-                                       screenRect.size.width,
-                                       bannerHeightDP);
-  }
 }
 
 - (void)requestAdWithTesting:(BOOL)isTesting


### PR DESCRIPTION
The Unity iOS plugin would fail to request any ads unless you passed in a valid JSON string for the 'extras' parameter of RequestBannerAd. This is different than the Android plugin, which has two version of that method: one with extras and one without. This change modifies the iOS API to accept null/nil for 'extras'.
