### PR TITLE
Added support for bottom banners in the iOS plugin

### DIFF
--- a/unity/iOS/Plugins/iOS/AdMobPlugin.mm
+++ b/unity/iOS/Plugins/iOS/AdMobPlugin.mm
@@ -135,6 +135,17 @@ extern UIViewController *UnityGetGLViewController();
   self.bannerView.adUnitID = pubId;
   self.bannerView.delegate = self;
   self.bannerView.rootViewController = UnityGetGLViewController();
+  if (positionAdAtTop_ == false) {
+    CGFloat bannerHeightDP = 50.0f;
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+      bannerHeightDP = 90.0f;
+    }
+    CGRect screenRect = [UIScreen mainScreen].bounds;
+    self.bannerView.frame = CGRectMake(screenRect.origin.x,
+                                       screenRect.size.height - bannerHeightDP,
+                                       screenRect.size.width,
+                                       bannerHeightDP);
+  }
 }
 
 - (void)requestAdWithTesting:(BOOL)isTesting


### PR DESCRIPTION
The iOS plugin accepts 'positionAtTop' for CreateBannerView but it didn't do anything with that parameter. It stored it in the plugin's 'positionAdAtTop_' data member but it didn't reference it afterwards. This change reads that flag and positions the bannerView at the bottom of the screen. However, it currently only supports portrait screen orientation banner heights.
