### PR TITLE
Automatically repositions banner to top or bottom of screen when rotating 90 degrees on iOS

### DIFF
--- a/unity/source/Assets/Plugins/iOS/GADUBanner.m
+++ b/unity/source/Assets/Plugins/iOS/GADUBanner.m
@@ -58,8 +58,7 @@
                            adUnitID:(NSString *)adUnitID
                              adSize:(GADAdSize)size
                          adPosition:(GADAdPosition)adPosition {
-  self = [super init];
-  if (self) {
+  if (self = [super init]) {
     _bannerClient = bannerClient;
     _adPosition = adPosition;
     _bannerView = [[GADBannerView alloc] initWithAdSize:size];
@@ -68,6 +67,9 @@
     UIViewController *unityController = [GADUBanner unityGLViewController];
     _bannerView.rootViewController = unityController;
     [unityController.view addSubview:_bannerView];
+        
+    [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(calculatePosition) name:UIDeviceOrientationDidChangeNotification object:nil];
   }
   return self;
 }
@@ -104,22 +106,30 @@
   [self.bannerView removeFromSuperview];
 }
 
+- (void) calculatePosition
+{
+    GADBannerView *adView = _bannerView;
+    if (adView) {
+        UIView *unityView = [[GADUBanner unityGLViewController] view];
+        CGPoint center;
+        // Position the GADBannerView.
+        switch (self.adPosition) {
+            case kGADAdPositionTopOfScreen:
+                center = CGPointMake(CGRectGetMidX(unityView.bounds), CGRectGetMidY(adView.bounds));
+                break;
+            case kGADAdPositionBottomOfScreen:
+                center = CGPointMake(CGRectGetMidX(unityView.bounds),
+                                     CGRectGetMaxY(unityView.bounds) - CGRectGetMidY(adView.bounds));
+                break;
+        }
+        adView.center = center;
+    }
+}
+
 #pragma mark GADBannerViewDelegate implementation
 
 - (void)adViewDidReceiveAd:(GADBannerView *)adView {
-  UIView *unityView = [[GADUBanner unityGLViewController] view];
-  CGPoint center;
-  // Position the GADBannerView.
-  switch (self.adPosition) {
-    case kGADAdPositionTopOfScreen:
-      center = CGPointMake(CGRectGetMidX(unityView.bounds), CGRectGetMidY(adView.bounds));
-      break;
-    case kGADAdPositionBottomOfScreen:
-      center = CGPointMake(CGRectGetMidX(unityView.bounds),
-                           CGRectGetMaxY(unityView.bounds) - CGRectGetMidY(adView.bounds));
-      break;
-  }
-  adView.center = center;
+  [self calculatePosition];
   if (self.adReceivedCallback) {
     self.adReceivedCallback(self.bannerClient);
   }
@@ -158,6 +168,7 @@
 #pragma mark Cleanup
 
 - (void)dealloc {
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
   _bannerView.delegate = nil;
   [_bannerView release];
   [super dealloc];

--- a/unity/source/Assets/Plugins/iOS/GADUBanner.m
+++ b/unity/source/Assets/Plugins/iOS/GADUBanner.m
@@ -69,7 +69,7 @@
     [unityController.view addSubview:_bannerView];
         
     [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(calculatePosition) name:UIDeviceOrientationDidChangeNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationDidChange) name:UIDeviceOrientationDidChangeNotification object:nil];
   }
   return self;
 }
@@ -124,6 +124,22 @@
         }
         adView.center = center;
     }
+}
+
+- (void) orientationDidChange
+{
+    GADBannerView *adView = _bannerView;
+    
+    UIDeviceOrientation currentOrientation = [[UIDevice currentDevice] orientation];
+    GADAdSize adSize;
+    if (UIInterfaceOrientationIsPortrait(currentOrientation)) {
+        adSize = kGADAdSizeSmartBannerPortrait;
+    } else {
+        adSize = kGADAdSizeSmartBannerLandscape;
+    }
+    adView.adSize = adSize;
+    
+    [self calculatePosition];
 }
 
 #pragma mark GADBannerViewDelegate implementation


### PR DESCRIPTION
Hi Google guys,

Just added a fix for this issue: https://github.com/googleads/googleads-mobile-plugins/issues/9
It works for iOS (haven't got the chance yet to see if this bug also exists on Android)

Cheers!