### PR TITLE
Delete PLUGIN_JAR_GOES_HERE

### DIFF
--- a/source/plugin/Assets/Plugins/Android/GoogleMobileAdsPlugin/libs/PLUGIN_JAR_GOES_HERE
+++ b/source/plugin/Assets/Plugins/Android/GoogleMobileAdsPlugin/libs/PLUGIN_JAR_GOES_HERE
@@ -1,4 +1,0 @@
-If you make changes to the Google Mobile Ads Android plugin library project
-at source/plugin-library, the new jar from source/plugin-library/bin should
-be placed here.
-


### PR DESCRIPTION
When this file is installed by the Unity plugin installer it causes the Android build to fail.