### PR TITLE
Fix warning relating to a null check on a value type

### DIFF
--- a/source/plugin/Assets/GoogleMobileAds/Platforms/iOS/AdLoaderClient.cs
+++ b/source/plugin/Assets/GoogleMobileAds/Platforms/iOS/AdLoaderClient.cs
@@ -53,7 +53,7 @@ namespace GoogleMobileAds.iOS
             }
             set
             {
-                if(adLoaderPtr != null)
+                if (adLoaderPtr != IntPtr.Zero)
                 {
                     Externs.GADURelease(adLoaderPtr);
                 }


### PR DESCRIPTION
adLoaderPtr is an IntPtr variable, which is a value type. This means it cannot be null so that code would never fire and it also results in a permenant warning in the Unity log when you have GoogleMobileAds imported.