### PR TITLE
Remove PLUGIN_JAR_GOES_HERE file

### DIFF
--- a/source/plugin/Assets/Plugins/Android/GoogleMobileAdsPlugin/libs/PLUGIN_JAR_GOES_HERE
+++ b/source/plugin/Assets/Plugins/Android/GoogleMobileAdsPlugin/libs/PLUGIN_JAR_GOES_HERE
@@ -1,4 +1,0 @@
-If you make changes to the Google Mobile Ads Android plugin library project
-at source/plugin-library, the new jar from source/plugin-library/bin should
-be placed here.
-


### PR DESCRIPTION
* This file breaks the resource merging that happens during Android builds