### PR TITLE
Suppress compiler warnings about never used events

### DIFF
--- a/source/plugin/Assets/GoogleMobileAds/Common/DummyClient.cs
+++ b/source/plugin/Assets/GoogleMobileAds/Common/DummyClient.cs
@@ -28,6 +28,7 @@ namespace GoogleMobileAds.Common
             Debug.Log("Dummy " + MethodBase.GetCurrentMethod().Name);
         }
 
+#pragma warning disable 67
         public event EventHandler<EventArgs> OnAdLoaded;
 
         public event EventHandler<AdFailedToLoadEventArgs> OnAdFailedToLoad;
@@ -43,6 +44,7 @@ namespace GoogleMobileAds.Common
         public event EventHandler<EventArgs> OnAdLeavingApplication;
 
         public event EventHandler<CustomNativeEventArgs> OnCustomNativeTemplateAdLoaded;
+#pragma warning restore 67
 
         public string UserId
         {


### PR DESCRIPTION
Suppress the following compiler warnings:
<img width="1017" alt="compilerwarnings" src="https://cloud.githubusercontent.com/assets/1635228/23247384/eab8a762-f9ed-11e6-9e3e-078d73c7a31e.png">