### PR TITLE
Fix not to create instance of AppLovinSdk class.

### DIFF
--- a/mediation/AppLovin/source/plugin/Assets/GoogleMobileAds/Platforms/Android/Mediation/AppLovin/AppLovinClient.cs
+++ b/mediation/AppLovin/source/plugin/Assets/GoogleMobileAds/Platforms/Android/Mediation/AppLovin/AppLovinClient.cs
@@ -39,7 +39,7 @@ namespace GoogleMobileAds.Android.Mediation.AppLovin
             MonoBehaviour.print("AppLovin intialize received");
             AndroidJavaClass unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer");
             AndroidJavaObject currentActivity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity");
-            AndroidJavaObject appLovin = new AndroidJavaObject("com.applovin.sdk.AppLovinSdk");
+            AndroidJavaClass appLovin = new AndroidJavaClass("com.applovin.sdk.AppLovinSdk");
             appLovin.CallStatic("initializeSdk", currentActivity);
         }
     }


### PR DESCRIPTION
Crash occurred if call `AppLovin.Initialize()`. Error message is bellow.

`JNI DETECTED ERROR IN APPLICATION: can't make objects of type com.applovin.sdk.AppLovinSdk`

The cause of the crash is that the `com.applovin.sdk.AppLovinSdk` class is an abstract class.
This PR is fixed it.
