### PR TITLE
Remove GoogleMobileAds directive

### DIFF
--- a/samples/HelloWorld/Assets/Scripts/GoogleMobileAdsDemoScript.cs
+++ b/samples/HelloWorld/Assets/Scripts/GoogleMobileAdsDemoScript.cs
@@ -1,6 +1,5 @@
 using System;
 using UnityEngine;
-using GoogleMobileAds;
 using GoogleMobileAds.Api;
 
 // Example script showing how to invoke the Google Mobile Ads Unity plugin.


### PR DESCRIPTION
I'm not sure if this was left intact for a specific purpose, but GoogleMobileAds directive doesn't seem to be needed in the latest SDK.