### PR TITLE
Using Unity Version of AdColony SDK

### DIFF
--- a/mediation/AdColony/source/plugin/Assets/GoogleMobileAds/Editor/AdColonyMediationDependencies.xml
+++ b/mediation/AdColony/source/plugin/Assets/GoogleMobileAds/Editor/AdColonyMediationDependencies.xml
@@ -5,7 +5,7 @@
         <repository>https://adcolony.bintray.com/AdColony</repository>
       </repositories>
     </androidPackage>
-    <androidPackage spec="com.adcolony:sdk:3.3.0">
+    <androidPackage spec="com.adcolony:sdk:3.3.0-unity">
       <repositories>
         <repository>https://adcolony.bintray.com/AdColony</repository>
       </repositories>


### PR DESCRIPTION
I have changed the AdColony mediation dependency to depend upon the Unity version of AdColony. This allows an Android Unity application to run properly on the arm64-v8a architecture.

The Unity version of the AdColony SDK only includes armeabi-v7a and x86 versions of the libraries. The non-unity version has 64-bit versions of the libraries as well.

When you run the application on a device with an arm64-v8a processor with the full library, it finds the two 64-bit AdColony libraries (libadcolony.so and libjs.so), and then crashes, for it expects to find 64-bit versions of all the other libraries (such as the Unity and Mono libraries) and they don't exist. [[Unity expects to offer beta support for 64-bit Android binaries in Unity 2018.2](https://blogs.unity3d.com/2017/12/20/meeting-google-play-requirements-in-the-future/)] 

Using the Unity version of the libraries, the processor loads the older architecture's library, finds matching libraries for other modules, and works fine.