### PR TITLE
Update AppLovinPostProcessBuild.cs

### DIFF
--- a/mediation/AppLovin/source/plugin/Assets/GoogleMobileAds/Editor/AppLovinPostProcessBuild.cs
+++ b/mediation/AppLovin/source/plugin/Assets/GoogleMobileAds/Editor/AppLovinPostProcessBuild.cs
@@ -11,7 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+#if UNITY_EDITOR_WIN
+#else
 using UnityEditor;
 using UnityEditor.Callbacks;
 using UnityEditor.iOS.Xcode;
@@ -40,3 +41,5 @@ namespace GoogleMobileAds.Common.Mediation.AppLovin
         }
     }
 }
+
+#endif


### PR DESCRIPTION
Using UnityEditor.iOS.Xcode in windows editor cause an error. Post process function can be striped on Windows, because build for ios should only be done thru OSX i think.