### PR TITLE
Update UnityMediationDependencies.xml

### DIFF
--- a/mediation/UnityAds/source/plugin/Assets/GoogleMobileAds/Editor/UnityMediationDependencies.xml
+++ b/mediation/UnityAds/source/plugin/Assets/GoogleMobileAds/Editor/UnityMediationDependencies.xml
@@ -13,7 +13,7 @@
   </androidPackages>
 
   <iosPods>
-    <iosPod name="GoogleMobileAdsMediationUnity" version="2.2.0.0">
+    <iosPod name="GoogleMobileAdsMediationUnity" version="2.1.2.0">
       <sources>
         <source>https://github.com/CocoaPods/Specs</source>
       </sources>


### PR DESCRIPTION
The latest version of the "GoogleMobileAdsMediationUnity" podfile is 2.1.2.0:

https://cocoapods.org/pods/GoogleMobileAdsMediationUnity#changelog

The current 'iosPod' dependency here requires version '2.2.1', which doesn't exiat. This causes a crash when building Unity for iOS, after importing this mediation package. 

Proposing to change this version to 2.1.2.0, which fixes the issue. Confirmed in my local project.