### PR TITLE
Changed Type.GetType to typeof in Api

### DIFF
--- a/source/plugin/Assets/GoogleMobileAds/Api/AdLoader.cs
+++ b/source/plugin/Assets/GoogleMobileAds/Api/AdLoader.cs
@@ -38,10 +38,9 @@ namespace GoogleMobileAds.Api
             this.TemplateIds = new HashSet<string>(builder.TemplateIds);
             this.AdTypes = new HashSet<NativeAdType>(builder.AdTypes);
 
-            Type googleMobileAdsClientFactory = Type.GetType(
-                "GoogleMobileAds.GoogleMobileAdsClientFactory,Assembly-CSharp");
+            Type googleMobileAdsClientFactory = typeof(GoogleMobileAdsClientFactory);
             MethodInfo method = googleMobileAdsClientFactory.GetMethod(
-                "BuildAdLoaderClient",
+                nameof(GoogleMobileAdsClientFactory.BuildAdLoaderClient),
                 BindingFlags.Static | BindingFlags.Public);
             this.adLoaderClient = (IAdLoaderClient)method.Invoke(null, new object[] { this });
 

--- a/source/plugin/Assets/GoogleMobileAds/Api/BannerView.cs
+++ b/source/plugin/Assets/GoogleMobileAds/Api/BannerView.cs
@@ -26,10 +26,9 @@ namespace GoogleMobileAds.Api
         // Creates a BannerView and adds it to the view hierarchy.
         public BannerView(string adUnitId, AdSize adSize, AdPosition position)
         {
-            Type googleMobileAdsClientFactory = Type.GetType(
-                "GoogleMobileAds.GoogleMobileAdsClientFactory,Assembly-CSharp");
+            Type googleMobileAdsClientFactory = typeof(GoogleMobileAdsClientFactory);
             MethodInfo method = googleMobileAdsClientFactory.GetMethod(
-                "BuildBannerClient",
+                nameof(GoogleMobileAdsClientFactory.BuildBannerClient),
                 BindingFlags.Static | BindingFlags.Public);
             this.client = (IBannerClient)method.Invoke(null, null);
             client.CreateBannerView(adUnitId, adSize, position);
@@ -40,10 +39,9 @@ namespace GoogleMobileAds.Api
         // Creates a BannerView with a custom position.
         public BannerView(string adUnitId, AdSize adSize, int x, int y)
         {
-            Type googleMobileAdsClientFactory = Type.GetType(
-                "GoogleMobileAds.GoogleMobileAdsClientFactory,Assembly-CSharp");
+            Type googleMobileAdsClientFactory = typeof(GoogleMobileAdsClientFactory);
             MethodInfo method = googleMobileAdsClientFactory.GetMethod(
-                "BuildBannerClient",
+                nameof(GoogleMobileAdsClientFactory.BuildBannerClient),
                 BindingFlags.Static | BindingFlags.Public);
             this.client = (IBannerClient)method.Invoke(null, null);
             client.CreateBannerView(adUnitId, adSize, x, y);

--- a/source/plugin/Assets/GoogleMobileAds/Api/InterstitialAd.cs
+++ b/source/plugin/Assets/GoogleMobileAds/Api/InterstitialAd.cs
@@ -26,10 +26,9 @@ namespace GoogleMobileAds.Api
         // Creates an InterstitialAd.
         public InterstitialAd(string adUnitId)
         {
-            Type googleMobileAdsClientFactory = Type.GetType(
-                "GoogleMobileAds.GoogleMobileAdsClientFactory,Assembly-CSharp");
+            Type googleMobileAdsClientFactory = typeof(GoogleMobileAdsClientFactory);
             MethodInfo method = googleMobileAdsClientFactory.GetMethod(
-                "BuildInterstitialClient",
+                nameof(GoogleMobileAdsClientFactory.BuildInterstitialClient),
                 BindingFlags.Static | BindingFlags.Public);
             this.client = (IInterstitialClient)method.Invoke(null, null);
             client.CreateInterstitialAd(adUnitId);

--- a/source/plugin/Assets/GoogleMobileAds/Api/MobileAds.cs
+++ b/source/plugin/Assets/GoogleMobileAds/Api/MobileAds.cs
@@ -46,10 +46,9 @@ namespace GoogleMobileAds.Api
 
         private static IMobileAdsClient GetMobileAdsClient()
         {
-            Type googleMobileAdsClientFactory = Type.GetType(
-                "GoogleMobileAds.GoogleMobileAdsClientFactory,Assembly-CSharp");
+            Type googleMobileAdsClientFactory = typeof(GoogleMobileAdsClientFactory);
             MethodInfo method = googleMobileAdsClientFactory.GetMethod(
-                "MobileAdsInstance",
+                nameof(GoogleMobileAdsClientFactory.MobileAdsInstance),
                 BindingFlags.Static | BindingFlags.Public);
             return (IMobileAdsClient)method.Invoke(null, null);
         }

--- a/source/plugin/Assets/GoogleMobileAds/Api/RewardBasedVideoAd.cs
+++ b/source/plugin/Assets/GoogleMobileAds/Api/RewardBasedVideoAd.cs
@@ -35,10 +35,9 @@ namespace GoogleMobileAds.Api
         // Creates a Singleton RewardBasedVideoAd.
         private RewardBasedVideoAd()
         {
-            Type googleMobileAdsClientFactory = Type.GetType(
-                "GoogleMobileAds.GoogleMobileAdsClientFactory,Assembly-CSharp");
+            Type googleMobileAdsClientFactory = typeof(GoogleMobileAdsClientFactory);
             MethodInfo method = googleMobileAdsClientFactory.GetMethod(
-                "BuildRewardBasedVideoAdClient",
+                nameof(GoogleMobileAdsClientFactory.BuildRewardBasedVideoAdClient),
                 BindingFlags.Static | BindingFlags.Public);
             this.client = (IRewardBasedVideoAdClient)method.Invoke(null, null);
             client.CreateRewardBasedVideoAd();


### PR DESCRIPTION
It prevents problems with using custom Assembly Definition for GoogleMobileAds.

Also changed getting method via string to nameof(), it adds compile-time checking for name.