### PR TITLE
Add mediationExtras with addCustomEventExtrasBundle()

### DIFF
--- a/source/plugin/Assets/GoogleMobileAds/Platforms/Android/Utils.cs
+++ b/source/plugin/Assets/GoogleMobileAds/Platforms/Android/Utils.cs
@@ -198,6 +198,11 @@ namespace GoogleMobileAds.Android
                         "addNetworkExtrasBundle",
                         mediationExtrasBundleBuilder.Call<AndroidJavaClass>("getAdapterClass"),
                         mediationExtras);
+
+                    adRequestBuilder.Call<AndroidJavaObject>(
+                        "addCustomEventExtrasBundle",
+                        mediationExtrasBundleBuilder.Call<AndroidJavaClass>("getAdapterClass"),
+                        mediationExtras);
                 }
             }
 


### PR DESCRIPTION
Third party custom events won't receive extras through `addNetworkExtrasBundle`, they must be added with `addCustomEventExtrasBundle`