### PR TITLE
Fixed ClassNotFoundException on API level 28+

### DIFF
--- a/source/plugin/Assets/Plugins/Android/GoogleMobileAdsPlugin/AndroidManifest.xml
+++ b/source/plugin/Assets/Plugins/Android/GoogleMobileAdsPlugin/AndroidManifest.xml
@@ -11,8 +11,8 @@ required for displaying ads.
   <uses-sdk android:minSdkVersion="14"
       android:targetSdkVersion="19" />
   <application>
-  <!-- Your AdMob App ID will look similar to this sample ID:
-    ca-app-pub-3940256099942544~3347511713 -->
+    <uses-library android:required="false" android:name="org.apache.http.legacy"/>
+    <!-- Your AdMob App ID will look similar to this sample ID: ca-app-pub-3940256099942544~3347511713 -->
     <meta-data
     android:name="com.google.android.gms.ads.APPLICATION_ID"
     android:value="[ADMOB APPLICATION ID]"/>


### PR DESCRIPTION
As per Behavior changes: apps targeting API level 28+ (https://developer.android.com/about/versions/pie/android-9.0-changes-28): Beginning with Android 9, the Apache HTTP client library is removed from the bootclasspath and is not available to apps by default.

"To continue using the Apache HTTP client, apps that target Android 9 and above can add the following to their AndroidManifest.xml:
<uses-library android:name="org.apache.http.legacy" android:required="false"/>"