### PR TITLE
Notify OnAdLoaded on LoadAd call

### DIFF
--- a/source/plugin/Assets/GoogleMobileAds/Common/RewardedAdDummyClient.cs
+++ b/source/plugin/Assets/GoogleMobileAds/Common/RewardedAdDummyClient.cs
@@ -52,6 +52,11 @@ namespace GoogleMobileAds.Common
         public void LoadAd(AdRequest request)
         {
             Debug.Log("Dummy " + MethodBase.GetCurrentMethod().Name);
+
+            if (OnAdLoaded != null)
+            {
+                OnAdLoaded(this, EventArgs.Empty);
+            }
         }
 
         public bool IsLoaded()


### PR DESCRIPTION
Enables OnAdLoaded testing with a dummy Reward Ad client.