### PR TITLE
Store adUnitId on ad creation

### DIFF
--- a/source/plugin/Assets/GoogleMobileAds/Api/BannerView.cs
+++ b/source/plugin/Assets/GoogleMobileAds/Api/BannerView.cs
@@ -22,9 +22,12 @@ namespace GoogleMobileAds.Api
     {
         private IBannerClient client;
 
+        public string AdUnitId { get; private set; }
+
         // Creates a BannerView and adds it to the view hierarchy.
         public BannerView(string adUnitId, AdSize adSize, AdPosition position)
         {
+            this.AdUnitId = adUnitId;
             this.client = GoogleMobileAdsClientFactory.BuildBannerClient();
             client.CreateBannerView(adUnitId, adSize, position);
 
@@ -34,6 +37,7 @@ namespace GoogleMobileAds.Api
         // Creates a BannerView with a custom position.
         public BannerView(string adUnitId, AdSize adSize, int x, int y)
         {
+            this.AdUnitId = adUnitId;
             this.client = GoogleMobileAdsClientFactory.BuildBannerClient();
             client.CreateBannerView(adUnitId, adSize, x, y);
 

--- a/source/plugin/Assets/GoogleMobileAds/Api/InterstitialAd.cs
+++ b/source/plugin/Assets/GoogleMobileAds/Api/InterstitialAd.cs
@@ -22,9 +22,12 @@ namespace GoogleMobileAds.Api
     {
         private IInterstitialClient client;
 
+        public string AdUnitId { get; private set; }
+
         // Creates an InterstitialAd.
         public InterstitialAd(string adUnitId)
         {
+            this.AdUnitId = adUnitId;
             this.client = GoogleMobileAdsClientFactory.BuildInterstitialClient();
             client.CreateInterstitialAd(adUnitId);
 

--- a/source/plugin/Assets/GoogleMobileAds/Api/RewardedAd.cs
+++ b/source/plugin/Assets/GoogleMobileAds/Api/RewardedAd.cs
@@ -22,8 +22,11 @@ namespace GoogleMobileAds.Api
     {
         private IRewardedAdClient client;
 
+        public string AdUnitId { get; private set; }
+
         public RewardedAd(string adUnitId)
         {
+            this.AdUnitId = adUnitId;
             this.client = GoogleMobileAdsClientFactory.BuildRewardedAdClient();
             client.CreateRewardedAd(adUnitId);
 


### PR DESCRIPTION
Add field to store the ad unit id passed in the creation of an ad (BannerView, InterstitialAd and RewardedAd). This way we can retrieve the ad unit id when we receive ad events.

Here is an example where we could use this stored ad unit id:
```cs
...
private void RequestInterstitial() {
    this.interstitial = new InterstitialAd("myUnitId");
    this.interstitial.OnAdLoaded += HandleOnAdLoaded;
}

public void HandleOnAdLoaded(object sender, EventArgs eventArgs) {
    var retrievedAdUnitId = ((InterstitialAd) sender).AdUnitId;
    Debug.LogFormat("HandleAdLoaded ad unit id {0}", retrievedAdUnitId);
}
...
```