### PR TITLE
Changed "GoogleMobileAdsSettings" file directory to Editor folder

### DIFF
--- a/source/plugin/Assets/GoogleMobileAds/Editor/GoogleMobileAdsSettings.cs
+++ b/source/plugin/Assets/GoogleMobileAds/Editor/GoogleMobileAdsSettings.cs
@@ -13,10 +13,10 @@ namespace GoogleMobileAds.Editor
     {
         private const string MobileAdsSettingsDir = "Assets/GoogleMobileAds";
 
-        private const string MobileAdsSettingsResDir = "Assets/GoogleMobileAds/Resources";
+        private const string MobileAdsSettingsResDir = "Assets/GoogleMobileAds/Editor/Resources";
 
         private const string MobileAdsSettingsFile =
-            "Assets/GoogleMobileAds/Resources/GoogleMobileAdsSettings.asset";
+            "Assets/GoogleMobileAds/Editor/Resources/GoogleMobileAdsSettings.asset";
 
         private static GoogleMobileAdsSettings instance;
 


### PR DESCRIPTION
The **GoogleMobileAdsSettings** file is unnecessary in the build. Otherwise, it causes warnings and errors on the device.
Fixes #1115  