### PR TITLE
Update Facebook Unity Mediation plugin.

### DIFF
--- a/mediation/Facebook/CHANGELOG.md
+++ b/mediation/Facebook/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Facebook Unity Mediation Plugin Changelog
 
+#### Version 2.7.2
+- Supports [Facebook Android adapter version 5.7.1.1](https://github.com/googleads/googleads-mobile-android-mediation/blob/master/ThirdPartyAdapters/facebook/CHANGELOG.md#5711).
+- Supports [Facebook iOS adapter version 5.7.1.2](https://github.com/googleads/googleads-mobile-ios-mediation/blob/master/adapters/Facebook/CHANGELOG.md#version-5712).
+
 #### Version 2.7.1
 - Supports [Facebook Android adapter version 5.7.1.0](https://github.com/googleads/googleads-mobile-android-mediation/blob/master/ThirdPartyAdapters/facebook/CHANGELOG.md#5710).
 - Supports [Facebook iOS adapter version 5.7.1.1](https://github.com/googleads/googleads-mobile-ios-mediation/blob/master/adapters/Facebook/CHANGELOG.md#version-5711).

--- a/mediation/Facebook/build.gradle
+++ b/mediation/Facebook/build.gradle
@@ -23,7 +23,7 @@ project.ext {
                 'UNITY_EXE environment variable and point it to your Unity installation.')
     }
 
-    versionString = '2.7.1'
+    versionString = '2.7.2'
     pluginName = 'GoogleMobileAdsFacebookMediation'
     pluginFileName = "${pluginName}.unitypackage"
     zipName = "${pluginName}-${versionString}"

--- a/mediation/Facebook/source/plugin/Assets/GoogleMobileAds/Editor/FacebookMediationDependencies.xml
+++ b/mediation/Facebook/source/plugin/Assets/GoogleMobileAds/Editor/FacebookMediationDependencies.xml
@@ -1,6 +1,6 @@
 <dependencies>
   <androidPackages>
-    <androidPackage spec="com.google.ads.mediation:facebook:5.7.1.0">
+    <androidPackage spec="com.google.ads.mediation:facebook:5.7.1.1">
       <repositories>
         <repository>https://jcenter.bintray.com/</repository>
       </repositories>
@@ -8,7 +8,7 @@
   </androidPackages>
 
   <iosPods>
-    <iosPod name="GoogleMobileAdsMediationFacebook" version="5.7.1.1">
+    <iosPod name="GoogleMobileAdsMediationFacebook" version="5.7.1.2">
       <sources>
         <source>https://github.com/CocoaPods/Specs</source>
       </sources>


### PR DESCRIPTION
Updating Facebook Unity Mediation plugin to support versions 5.7.1.1 and 5.7.1.2 of the Android and iOS adapters.