### PR TITLE
Added InitializationStatusClient and patched null pointer crash

### DIFF
--- a/source/plugin/Assets/GoogleMobileAds/Common/DummyClient.cs
+++ b/source/plugin/Assets/GoogleMobileAds/Common/DummyClient.cs
@@ -77,7 +77,7 @@ namespace GoogleMobileAds.Common
         public void Initialize(Action<IInitializationStatusClient> initCompleteAction)
         {
             Debug.Log("Dummy " + MethodBase.GetCurrentMethod().Name);
-            var initStatusClient = new InitializationStatusClient();
+            var initStatusClient = new InitializationStatusDummyClient();
             initCompleteAction(initStatusClient);
         }
 

--- a/source/plugin/Assets/GoogleMobileAds/Common/DummyClient.cs
+++ b/source/plugin/Assets/GoogleMobileAds/Common/DummyClient.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Reflection;
 
+using GoogleMobileAds.Unity;
 using GoogleMobileAds.Api;
 using UnityEngine;
 
@@ -76,7 +77,8 @@ namespace GoogleMobileAds.Common
         public void Initialize(Action<IInitializationStatusClient> initCompleteAction)
         {
             Debug.Log("Dummy " + MethodBase.GetCurrentMethod().Name);
-            initCompleteAction(null);
+            var initStatusClient = new InitializationStatusClient();
+            initCompleteAction(initStatusClient);
         }
 
         public void DisableMediationInitialization()

--- a/source/plugin/Assets/GoogleMobileAds/Platforms/Unity/InitializationStatusClient
+++ b/source/plugin/Assets/GoogleMobileAds/Platforms/Unity/InitializationStatusClient
@@ -1,0 +1,39 @@
+// Copyright (C) 2020 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using GoogleMobileAds.Api;
+using GoogleMobileAds.Common;
+using UnityEngine;
+
+namespace GoogleMobileAds.Unity
+{
+    public class InitializationStatusClient : IInitializationStatusClient
+    {
+        public AdapterStatus getAdapterStatusForClassName(string className)
+        {
+            AdapterState adapterState = AdapterState.Ready;
+            string testDescription = "Ready";
+            int testLatency = 0;
+            return new AdapterStatus(adapterState, testDescription, testLatency);
+        }
+
+        public Dictionary<string, AdapterStatus> getAdapterStatusMap()
+        {
+            Dictionary<string, AdapterStatus> dummyDictionary = new Dictionary<string,AdapterStatus>();
+            dummyDictionary.Add("ExampleClass", getAdapterStatusForClassName("ExampleClass"));
+            return dummyDictionary;
+        }
+    }
+}

--- a/source/plugin/Assets/GoogleMobileAds/Platforms/Unity/InitializationStatusDummyClient
+++ b/source/plugin/Assets/GoogleMobileAds/Platforms/Unity/InitializationStatusDummyClient
@@ -19,7 +19,7 @@ using UnityEngine;
 
 namespace GoogleMobileAds.Unity
 {
-    public class InitializationStatusClient : IInitializationStatusClient
+    public class InitializationStatusDummyClient : IInitializationStatusClient
     {
         public AdapterStatus getAdapterStatusForClassName(string className)
         {


### PR DESCRIPTION
Created a mock Unity specific InitializationStatusClient and used that in the dummy client as opposed to using null which was creating crashes. 