### PR TITLE
Update GADUInterstitial.m to better handle shutdown seqence

### DIFF
--- a/source/plugin/Assets/Plugins/iOS/GADUInterstitial.m
+++ b/source/plugin/Assets/Plugins/iOS/GADUInterstitial.m
@@ -97,6 +97,13 @@
 }
 
 - (void)interstitialDidDismissScreen:(GADInterstitial *)ad {
+  extern bool _didResignActive;
+  if(_didResignActive) {
+    // We are in the middle of the shutdown sequence, and at this point unity runtime is already destroyed.
+    // We shall not call unity API, and definitely not script callbacks, so nothing to do here
+    return;
+  }
+
   if (UnityIsPaused()) {
     UnityPause(NO);
   }


### PR DESCRIPTION
We can end up in interstitialDidDismissScreen on shutdown seqence, and this will happen AFTER unity runtime was already killed. At this point we should not call unity api and absolutely not script callbacks