### PR TITLE
Update GADURewardBasedVideoAd.m to better handle shutdown sequence

### DIFF
--- a/source/plugin/Assets/Plugins/iOS/GADURewardBasedVideoAd.m
+++ b/source/plugin/Assets/Plugins/iOS/GADURewardBasedVideoAd.m
@@ -93,6 +93,12 @@
 }
 
 - (void)rewardBasedVideoAdDidClose:(GADRewardBasedVideoAd *)rewardBasedVideoAd {
+  extern bool _didResignActive;
+  if(_didResignActive) {
+       // We are in the middle of the shutdown sequence, and at this point unity runtime is already destroyed.
+       // We shall not call unity API, and definitely not script callbacks, so nothing to do here
+    return;
+  }
   if (UnityIsPaused()) {
     UnityPause(NO);
   }


### PR DESCRIPTION
This is like issue 1441 but for RewardedAds : https://github.com/googleads/googleads-mobile-unity/pull/1441.