### PR TITLE
Update RewardAd for better handle shutdown sequence

### DIFF
--- a/source/plugin/Assets/Plugins/iOS/GADURewardBasedVideoAd.m
+++ b/source/plugin/Assets/Plugins/iOS/GADURewardBasedVideoAd.m
@@ -93,6 +93,12 @@
 }
 
 - (void)rewardBasedVideoAdDidClose:(GADRewardBasedVideoAd *)rewardBasedVideoAd {
+  extern bool _didResignActive;
+  if(_didResignActive) {
+    // We are in the middle of the shutdown sequence, and at this point unity runtime is already destroyed.
+    // We shall not call unity API, and definitely not script callbacks, so nothing to do here
+    return;
+  }
   if (UnityIsPaused()) {
     UnityPause(NO);
   }

--- a/source/plugin/Assets/Plugins/iOS/GADURewardedAd.m
+++ b/source/plugin/Assets/Plugins/iOS/GADURewardedAd.m
@@ -113,6 +113,12 @@
 }
 
 - (void)rewardedAdDidDismiss:(nonnull GADRewardedAd *)rewardedAd {
+  extern bool _didResignActive;
+  if(_didResignActive) {
+       // We are in the middle of the shutdown sequence, and at this point unity runtime is already destroyed.
+       // We shall not call unity API, and definitely not script callbacks, so nothing to do here
+    return;
+  }
   if (UnityIsPaused()) {
     UnityPause(NO);
   }

--- a/source/plugin/Assets/Plugins/iOS/GADURewardedInterstitialAd.m
+++ b/source/plugin/Assets/Plugins/iOS/GADURewardedInterstitialAd.m
@@ -106,6 +106,12 @@
 }
 
 - (void)adDidDismissFullScreenContent:(nonnull id<GADFullScreenPresentingAd>)ad {
+  extern bool _didResignActive;
+  if(_didResignActive) {
+    // We are in the middle of the shutdown sequence, and at this point unity runtime is already destroyed.
+    // We shall not call unity API, and definitely not script callbacks, so nothing to do here
+    return;
+  }
   if (UnityIsPaused()) {
     UnityPause(NO);
   }


### PR DESCRIPTION
This is issue 1441 but for rewarded ads https://github.com/googleads/googleads-mobile-unity/pull/1441/