### PR TITLE
Always show dummy ads above game's user interface

### DIFF
--- a/source/plugin/Assets/GoogleMobileAds/Platforms/Unity/DummyAdBehaviour.cs
+++ b/source/plugin/Assets/GoogleMobileAds/Platforms/Unity/DummyAdBehaviour.cs
@@ -31,7 +31,9 @@ public class DummyAdBehaviour : MonoBehaviour
 
     public GameObject ShowAd(GameObject dummyAd, Vector3 position)
     {
-       return Instantiate(dummyAd, position, Quaternion.identity) as GameObject;
+       var ad = Instantiate(dummyAd, position, Quaternion.identity) as GameObject;
+       ad.GetComponent<Canvas>().sortingOrder = 32767;
+       return ad;
     }
 
     public void DestroyAd(GameObject dummyAd)


### PR DESCRIPTION
Ensures that the dummy ads appear above the game's UI by setting the canvas sorting order to the maximum value: 32767