### PR TITLE
Fixed the problem of App ID not being saved

### DIFF
--- a/source/plugin/Assets/GoogleMobileAds/Editor/GoogleMobileAdsSettingsEditor.cs
+++ b/source/plugin/Assets/GoogleMobileAds/Editor/GoogleMobileAdsSettingsEditor.cs
@@ -3,8 +3,7 @@ using UnityEngine;
 
 namespace GoogleMobileAds.Editor
 {
-
-    [InitializeOnLoad]
+    
     [CustomEditor(typeof(GoogleMobileAdsSettings))]
     public class GoogleMobileAdsSettingsEditor : UnityEditor.Editor
     {
@@ -16,6 +15,8 @@ namespace GoogleMobileAds.Editor
 
         public override void OnInspectorGUI()
         {
+            EditorGUI.BeginChangeCheck();
+            
             EditorGUILayout.LabelField("Google Mobile Ads App ID", EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
 
@@ -37,8 +38,6 @@ namespace GoogleMobileAds.Editor
             EditorGUILayout.LabelField("AdMob-specific settings", EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
 
-            EditorGUI.BeginChangeCheck();
-
             GoogleMobileAdsSettings.Instance.DelayAppMeasurementInit =
                     EditorGUILayout.Toggle(new GUIContent("Delay app measurement"),
                     GoogleMobileAdsSettings.Instance.DelayAppMeasurementInit);
@@ -52,7 +51,7 @@ namespace GoogleMobileAds.Editor
             EditorGUI.indentLevel--;
             EditorGUILayout.Separator();
 
-            if (GUI.changed)
+            if (EditorGUI.EndChangeCheck())
             {
                 OnSettingsChanged();
             }


### PR DESCRIPTION
#1781 The value was not saved even though I fixed this problem.
After further investigation, I found that `GUI.changed` was not working.

**[REQUIRED] Step 1: Describe your environment**
- Unity version: 2020.3.19f1
- Google Mobile Ads Unity plugin version: 6.1.1
- Platform: Unity Editor (iOS, Android, Unity Editor)
- Platform OS version: Mac OS X Big Sur (eg iOS 10, Android 9)
- Any specific devices issue occurs on: PC
- Mediation ad networks used, and their versions: None

**[REQUIRED] Step 2: Describe the problem**
Steps to reproduce:
1. Create a project and import Google ads SDK in it
2. Click on Assets/Google Mobile Ads/Settings...
3. Set the App ID.
4. Reboot Unity.
5. Click on Assets/Google Mobile Ads/Settings...

APP ID was not saved.