### PR TITLE
Fix GoogleMobileAdsSettings not saving settings to file

### DIFF
--- a/source/plugin/Assets/GoogleMobileAds/Editor/GoogleMobileAdsSettings.cs
+++ b/source/plugin/Assets/GoogleMobileAds/Editor/GoogleMobileAdsSettings.cs
@@ -55,22 +55,22 @@ namespace GoogleMobileAds.Editor
                 {
                     return instance;
                 }
-
+                
                 instance = Resources.Load<GoogleMobileAdsSettings>(MobileAdsSettingsFile);
 
-                Directory.CreateDirectory(MobileAdsSettingsResDir);
-
-                instance = ScriptableObject.CreateInstance<GoogleMobileAdsSettings>();
-
-                string assetPath = Path.Combine(MobileAdsSettingsResDir, MobileAdsSettingsFile);
-                string assetPathWithExtension = Path.ChangeExtension(
-                                                        assetPath, MobileAdsSettingsFileExtension);
-                AssetDatabase.CreateAsset(instance, assetPathWithExtension);
+                if (!instance)
+                {
+                    Directory.CreateDirectory(MobileAdsSettingsResDir);
+                    instance = ScriptableObject.CreateInstance<GoogleMobileAdsSettings>();
+                    string assetPath = Path.Combine(MobileAdsSettingsResDir, MobileAdsSettingsFile);
+                    string assetPathWithExtension = Path.ChangeExtension(assetPath, MobileAdsSettingsFileExtension);
+                    AssetDatabase.CreateAsset(instance, assetPathWithExtension);
+                }
 
                 return instance;
             }
         }
-
+        
         internal void WriteSettingsToFile()
         {
             AssetDatabase.SaveAssets();

--- a/source/plugin/Assets/GoogleMobileAds/Editor/GoogleMobileAdsSettingsEditor.cs
+++ b/source/plugin/Assets/GoogleMobileAds/Editor/GoogleMobileAdsSettingsEditor.cs
@@ -3,7 +3,6 @@ using UnityEngine;
 
 namespace GoogleMobileAds.Editor
 {
-
     [InitializeOnLoad]
     [CustomEditor(typeof(GoogleMobileAdsSettings))]
     public class GoogleMobileAdsSettingsEditor : UnityEditor.Editor
@@ -14,54 +13,50 @@ namespace GoogleMobileAds.Editor
             Selection.activeObject = GoogleMobileAdsSettings.Instance;
         }
 
+        private SerializedProperty adMobAndroidAppId;
+        private SerializedProperty adMobIOSAppId;
+        private SerializedProperty delayAppMeasurementInit;
+
+        private void OnEnable()
+        {
+            adMobAndroidAppId = serializedObject.FindProperty("adMobAndroidAppId");
+            adMobIOSAppId = serializedObject.FindProperty("adMobIOSAppId");
+            delayAppMeasurementInit = serializedObject.FindProperty("delayAppMeasurementInit");
+        }
+
         public override void OnInspectorGUI()
         {
+            serializedObject.Update();
             EditorGUILayout.LabelField("Google Mobile Ads App ID", EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
 
-            GoogleMobileAdsSettings.Instance.GoogleMobileAdsAndroidAppId =
-                    EditorGUILayout.TextField("Android",
-                            GoogleMobileAdsSettings.Instance.GoogleMobileAdsAndroidAppId);
+            EditorGUI.BeginChangeCheck();
 
-            GoogleMobileAdsSettings.Instance.GoogleMobileAdsIOSAppId =
-                    EditorGUILayout.TextField("iOS",
-                            GoogleMobileAdsSettings.Instance.GoogleMobileAdsIOSAppId);
-
+            adMobAndroidAppId.stringValue = EditorGUILayout.TextField("Android" , adMobAndroidAppId.stringValue);            
+            adMobIOSAppId.stringValue = EditorGUILayout.TextField("iOS" , adMobIOSAppId.stringValue);
             EditorGUILayout.HelpBox(
                     "Google Mobile  Ads App ID will look similar to this sample ID: ca-app-pub-3940256099942544~3347511713",
                     MessageType.Info);
-
             EditorGUI.indentLevel--;
             EditorGUILayout.Separator();
 
             EditorGUILayout.LabelField("AdMob-specific settings", EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
+            delayAppMeasurementInit.boolValue = EditorGUILayout.Toggle(new GUIContent("Delay app measurement") , delayAppMeasurementInit.boolValue);
 
-            EditorGUI.BeginChangeCheck();
-
-            GoogleMobileAdsSettings.Instance.DelayAppMeasurementInit =
-                    EditorGUILayout.Toggle(new GUIContent("Delay app measurement"),
-                    GoogleMobileAdsSettings.Instance.DelayAppMeasurementInit);
-
-            if (GoogleMobileAdsSettings.Instance.DelayAppMeasurementInit) {
+            if (delayAppMeasurementInit.boolValue) {
                 EditorGUILayout.HelpBox(
                         "Delays app measurement until you explicitly initialize the Mobile Ads SDK or load an ad.",
                         MessageType.Info);
             }
-
             EditorGUI.indentLevel--;
             EditorGUILayout.Separator();
+            serializedObject.ApplyModifiedProperties();
 
-            if (GUI.changed)
+            if (EditorGUI.EndChangeCheck())
             {
-                OnSettingsChanged();
+                GoogleMobileAdsSettings.Instance.WriteSettingsToFile();
             }
-        }
-
-        private void OnSettingsChanged()
-        {
-            EditorUtility.SetDirty((GoogleMobileAdsSettings) target);
-            GoogleMobileAdsSettings.Instance.WriteSettingsToFile();
         }
     }
 }


### PR DESCRIPTION
Even that the issue was marked previously as fixed. Me and other users appears to still have the issue.

I know some Unity Editor scripting, i did a code review of that part of the code and i found that the approarch that was using to save fields was not correct.

Marking an Scriptable Object as Dirty does not actually saves the changes to disk, the correct way to do that is using SerializedProperty, and also is not needed to create a new ScriptableObject instance each time we want to edit settings, it must be created only when no Instance is found in the Unity project, or otherwise it will override the current settings with empty fields.

I tested the changes with my current project and it works great