### PR TITLE
Fix #1615: Add GUILayout.Button to save AppIDs

### DIFF
--- a/source/plugin/Assets/GoogleMobileAds/Editor/GoogleMobileAdsSettingsEditor.cs
+++ b/source/plugin/Assets/GoogleMobileAds/Editor/GoogleMobileAdsSettingsEditor.cs
@@ -52,7 +52,7 @@ namespace GoogleMobileAds.Editor
             EditorGUI.indentLevel--;
             EditorGUILayout.Separator();
 
-            if (EditorGUI.EndChangeCheck())
+            if (EditorGUI.EndChangeCheck() || GUILayout.Button("Save"))
             {
                 EditorUtility.SetDirty((GoogleMobileAdsSettings)target);
                 AssetDatabase.SaveAssets();


### PR DESCRIPTION
Resolve #1615 issue. `EditorGUI.EndChangeCheck()` method is not called when the TextField input changes.

So far, two solutions have been proposed:
1 - Tick / Untick "Delay App Measurement" checkbox.
2 - Edit `\Assets\GoogleMobileAds\Resources\GoogleMobileAdsSettings.asset`, and add manually your AppID.

I suggest adding a save button so that instead of searching the forums for an answer, people at least click that button.

![image](https://user-images.githubusercontent.com/46666053/161991819-69fd3c6e-8db0-446f-a8a6-dbadbbbcb189.png)
