### PR TITLE
Interstitial events now use MobileAds.RaiseAction

### DIFF
--- a/source/plugin/Assets/GoogleMobileAds/Api/InterstitialAd.cs
+++ b/source/plugin/Assets/GoogleMobileAds/Api/InterstitialAd.cs
@@ -138,49 +138,67 @@ namespace GoogleMobileAds.Api
         {
             _client.OnAdClicked += () =>
             {
-                if (OnAdClicked != null)
+                MobileAds.RaiseAction(() =>
                 {
-                    OnAdClicked();
-                }
+                    if (OnAdClicked != null)
+                    {
+                        OnAdClicked();
+                    }
+                });
             };
 
             _client.OnAdDidDismissFullScreenContent += (sender, args) =>
             {
-                if (OnAdFullScreenContentClosed != null)
+                MobileAds.RaiseAction(() =>
                 {
-                    OnAdFullScreenContentClosed();
-                }
+                    if (OnAdFullScreenContentClosed != null)
+                    {
+                        OnAdFullScreenContentClosed();
+                    }
+                });
             };
 
             _client.OnAdDidPresentFullScreenContent += (sender, args) =>
             {
-                if (OnAdFullScreenContentOpened != null)
+                MobileAds.RaiseAction(() =>
                 {
-                    OnAdFullScreenContentOpened();
-                }
+                    if (OnAdFullScreenContentOpened != null)
+                    {
+                        OnAdFullScreenContentOpened();
+                    }
+                });
             };
 
             _client.OnAdDidRecordImpression += (sender, args) =>
             {
-                if (OnAdImpressionRecorded != null)
+                MobileAds.RaiseAction(() =>
                 {
-                    OnAdImpressionRecorded();
-                }
+                    if (OnAdImpressionRecorded != null)
+                    {
+                        OnAdImpressionRecorded();
+                    }
+                });
             };
             _client.OnAdFailedToPresentFullScreenContent += (sender, error) =>
             {
                 var adError = new AdError(error.AdErrorClient);
-                if (OnAdFullScreenContentFailed != null)
+                MobileAds.RaiseAction(() =>
                 {
-                    OnAdFullScreenContentFailed(adError);
-                }
+                    if (OnAdFullScreenContentFailed != null)
+                    {
+                        OnAdFullScreenContentFailed(adError);
+                    }
+                });
             };
             _client.OnPaidEvent += (sender, args) =>
             {
-                if (OnAdPaid != null)
+                MobileAds.RaiseAction(() =>
                 {
-                    OnAdPaid(args.AdValue);
-                }
+                    if (OnAdPaid != null)
+                    {
+                        OnAdPaid(args.AdValue);
+                    }
+                });
             };
         }
     }


### PR DESCRIPTION
See issue: #2676

Identified that InterstitialAd.cs did not use MobileAds.RaiseAction for its ad events. This has now been fixed.