### PR TITLE
Fix compilation errors

### DIFF
--- a/source/plugin/Assets/GoogleMobileAds/Editor/AndroidBuildPostProcessor.cs
+++ b/source/plugin/Assets/GoogleMobileAds/Editor/AndroidBuildPostProcessor.cs
@@ -11,7 +11,7 @@ public static class AndroidBuildPostProcessor
     [PostProcessBuild]
     public static void OnPostProcessBuild(BuildTarget buildTarget, string path)
     {
-        if (GoogleMobileAdsSettings.Instance.GoogleMobileAdsAndroidAppId.Length == 0)
+        if (GoogleMobileAdsSettings.LoadInstance().GoogleMobileAdsAndroidAppId.Length == 0)
         {
             NotifyBuildFailure(
                 "Android Google Mobile Ads app ID is empty. Please enter a valid app ID to run ads properly.");

--- a/source/plugin/Assets/GoogleMobileAds/Platforms/iOS/AdapterResponseInfoClient.cs
+++ b/source/plugin/Assets/GoogleMobileAds/Platforms/iOS/AdapterResponseInfoClient.cs
@@ -1,3 +1,4 @@
+#if UNITY_IOS
 // Copyright (C) 2022 Google, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -115,3 +116,4 @@ namespace GoogleMobileAds.iOS
         }
     }
 }
+#endif


### PR DESCRIPTION
## Changes
1. **GoogleMobileAdsSettings** class doesn't have an Instance variable, I would suggest replacing it with **LoadInstance()** which returns an Instance.
2. The **AdapterResponseInfoClient** class appears to be an **iOS platform class**, but it is missing an **iOS platform define**, which is causing the error.
I fixed it by adding the **iOS platform define** as I did with the **other iOS platform classes**, so that the error doesn't occur.