### PR TITLE
fixed issue #2944

### DIFF
--- a/source/plugin/Assets/GoogleMobileAds/Editor/GoogleMobileAdsDependencies.xml
+++ b/source/plugin/Assets/GoogleMobileAds/Editor/GoogleMobileAdsDependencies.xml
@@ -5,8 +5,17 @@
         <repository>https://maven.google.com/</repository>
       </repositories>
     </androidPackage>
+    <androidPackage spec="androidx.lifecycle:lifecycle-common-java8:2.4.1">
+      <repositories>
+        <repository>https://maven.google.com/</repository>
+      </repositories>
+    </androidPackage>
+    <androidPackage spec="androidx.lifecycle:lifecycle-process:2.4.1">
+      <repositories>
+        <repository>https://maven.google.com/</repository>
+      </repositories>
+    </androidPackage>
   </androidPackages>
-
   <iosPods>
     <iosPod name="Google-Mobile-Ads-SDK" version="~> 10.9">
       <sources>


### PR DESCRIPTION
AppStateEventNotifier.AppStateChanged not calling while app goes in background or foreground in android device v 8.5.2 (Issue #2944)

- added dependency that is required in  GoogleMobileAdsDependencies.xml
