### PR TITLE
fix: Update Tapjoy DummyClient namespace path

### DIFF
--- a/mediation/Tapjoy/source/plugin/Assets/GoogleMobileAds/Mediation/Tapjoy/Platforms/Mediation/TapjoyClientFactory.cs
+++ b/mediation/Tapjoy/source/plugin/Assets/GoogleMobileAds/Mediation/Tapjoy/Platforms/Mediation/TapjoyClientFactory.cs
@@ -31,7 +31,7 @@ namespace GoogleMobileAds.Mediation.Tapjoy
             #elif UNITY_IOS
             return GoogleMobileAds.Mediation.Tapjoy.iOS.TapjoyClient.Instance;
             #else
-            return new GoogleMobileAds.Mediation.Common.Tapjoy.DummyClient();
+            return new GoogleMobileAds.Mediation.Tapjoy.Common.DummyClient();
             #endif
         }
     }


### PR DESCRIPTION
Prevent following error

`
Assets\GoogleMobileAds\Mediation\Tapjoy\Platforms\Mediation\TapjoyClientFactory.cs(34,50): error CS0234: The type or namespace name 'Common' does not exist in the namespace 'GoogleMobileAds.Mediation' (are you missing an assembly reference?)
`

Google Mobile Ads Unity plugin version: 8.6.0