### PR TITLE
Added proguard keep rules for Google Mobile Ads Android library

### DIFF
--- a/source/android-library/app/proguard.pgcfg
+++ b/source/android-library/app/proguard.pgcfg
@@ -21,7 +21,22 @@
    *;
 }
 
+# Keep Google Mobile Ads Android classes.
+-keep class com.google.android.gms.ads.** { 
+   *; 
+}
+
+# Keep Google Mobile Ads Android Mediation classes
+-keep class com.google.ads.mediation.** {
+   *;
+}
+
 # Keep User Messaging Platform Unity plugin classes.
 -keep class com.google.unity.ump.** {
+   *;
+}
+
+# Keep User Messaging Platform Android classes
+-keep class com.google.android.ump.** {
    *;
 }


### PR DESCRIPTION
This will allow using minification in Unity build for Android.
Fixes 
* https://github.com/googleads/googleads-mobile-unity/issues/3078
* https://github.com/googleads/googleads-mobile-unity/issues/2458
and other ClassNotFoundException issues